### PR TITLE
Nimble: drop explicit linking with `swiftXCTest`.

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -317,6 +317,8 @@
 		7B5358BE1C38479700A23FAA /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358BD1C38479700A23FAA /* SatisfyAnyOf.swift */; };
 		7B5358BF1C38479700A23FAA /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358BD1C38479700A23FAA /* SatisfyAnyOf.swift */; };
 		7B5358C01C38479700A23FAA /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5358BD1C38479700A23FAA /* SatisfyAnyOf.swift */; };
+		94C3A73A255AB42200A0407E /* Difference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C3A738255AB42200A0407E /* Difference.swift */; };
+		94C3AAF1255D4BA500A0407E /* DifferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C3A743255AB42D00A0407E /* DifferenceTests.swift */; };
 		964CFEFD1C4FF48900513336 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
 		964CFEFE1C4FF48900513336 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
 		964CFEFF1C4FF48900513336 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */; };
@@ -611,6 +613,8 @@
 		7B5358BD1C38479700A23FAA /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SatisfyAnyOf.swift; sourceTree = "<group>"; };
 		7B5358C11C39155600A23FAA /* ObjCSatisfyAnyOfTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCSatisfyAnyOfTest.m; sourceTree = "<group>"; };
 		8DF1C3F61C94FC75004B2D36 /* ObjcStringersTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjcStringersTest.m; sourceTree = "<group>"; };
+		94C3A738255AB42200A0407E /* Difference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Difference.swift; sourceTree = "<group>"; };
+		94C3A743255AB42D00A0407E /* DifferenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DifferenceTests.swift; sourceTree = "<group>"; };
 		964CFEFC1C4FF48900513336 /* ThrowAssertion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowAssertion.swift; sourceTree = "<group>"; };
 		965B0D081B62B8ED0005AE66 /* ObjCUserDescriptionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCUserDescriptionTest.m; sourceTree = "<group>"; };
 		965B0D0B1B62C06D0005AE66 /* UserDescriptionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDescriptionTest.swift; sourceTree = "<group>"; };
@@ -776,6 +780,7 @@
 		1F1A74381940169200FFFC47 /* NimbleTests */ = {
 			isa = PBXGroup;
 			children = (
+				94C3A743255AB42D00A0407E /* DifferenceTests.swift */,
 				CDC157902511957100EAA480 /* DSLTest.swift */,
 				CDBC39B82462EA7D00069677 /* PredicateTest.swift */,
 				1F0648D31963AAB2001F9C46 /* SynchronousTest.swift */,
@@ -896,6 +901,7 @@
 			isa = PBXGroup;
 			children = (
 				1FD8CD261968AB07008ED995 /* Await.swift */,
+				94C3A738255AB42200A0407E /* Difference.swift */,
 				1FD8CD271968AB07008ED995 /* SourceLocation.swift */,
 				1FD8CD281968AB07008ED995 /* Stringers.swift */,
 				AE4BA9AC1C88DDB500B73906 /* Errors.swift */,
@@ -1357,6 +1363,7 @@
 				1F1871C61CA89EDB00A34BF2 /* DSL.m in Sources */,
 				1FD8CD301968AB07008ED995 /* AdapterProtocols.swift in Sources */,
 				AE7ADE451C80BF8000B94CD3 /* MatchError.swift in Sources */,
+				94C3A73A255AB42200A0407E /* Difference.swift in Sources */,
 				1FC494AA1C29CBA40010975C /* NimbleEnvironment.swift in Sources */,
 				CDD80B841F20307A0002CD65 /* MatcherProtocols.swift in Sources */,
 				1FD8CD5E1968AB07008ED995 /* RaisesException.swift in Sources */,
@@ -1409,6 +1416,7 @@
 				1F925F02195C189500ED456B /* ContainTest.swift in Sources */,
 				A8A3B6FC2073644600E25A08 /* ObjcStringersTest.m in Sources */,
 				1F4A56881A3B33CB009E1637 /* ObjCBeFalsyTest.m in Sources */,
+				94C3AAF1255D4BA500A0407E /* DifferenceTests.swift in Sources */,
 				1F4A568E1A3B342B009E1637 /* ObjCBeFalseTest.m in Sources */,
 				1F925F11195C190B00ED456B /* BeGreaterThanOrEqualToTest.swift in Sources */,
 				1F925EEF195C136500ED456B /* BeLogicalTest.swift in Sources */,

--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -1970,7 +1970,6 @@
 					"$(inherited)",
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
@@ -2009,7 +2008,6 @@
 					"$(inherited)",
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
@@ -2095,7 +2093,6 @@
 					"$(inherited)",
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
@@ -2135,7 +2132,6 @@
 					"$(inherited)",
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
@@ -2223,7 +2219,6 @@
 					"$(inherited)",
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;
@@ -2262,7 +2257,6 @@
 					"$(inherited)",
 					"-weak_framework",
 					XCTest,
-					"-weak-lswiftXCTest",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "net.jeffhui.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_MODULE_NAME = Nimble;

--- a/Sources/Nimble/Utils/Difference.swift
+++ b/Sources/Nimble/Utils/Difference.swift
@@ -1,0 +1,365 @@
+//
+//  Difference.swift
+//  Difference
+//
+//  Created by Krzysztof Zablocki on 18.10.2017
+//  Copyright © 2017 Krzysztof Zablocki. All rights reserved.
+//
+
+import Foundation
+
+private typealias IndentationType = Difference.IndentationType
+
+private struct Differ {
+    private let indentationType: IndentationType
+    private let skipPrintingOnDiffCount: Bool
+
+    init(
+        indentationType: IndentationType,
+        skipPrintingOnDiffCount: Bool
+    ) {
+        self.indentationType = indentationType
+        self.skipPrintingOnDiffCount = skipPrintingOnDiffCount
+    }
+
+    func diff<T>(_ expected: T, _ received: T) -> [String] {
+        let lines = diffLines(expected, received, level: 0)
+        return buildLineContents(lines: lines)
+    }
+
+    fileprivate func diffLines<T>(_ expected: T, _ received: T, level: Int = 0) -> [Line] {
+        let expectedMirror = Mirror(reflecting: expected)
+        let receivedMirror = Mirror(reflecting: received)
+
+        guard expectedMirror.children.count != 0, receivedMirror.children.count != 0 else {
+            if String(dumping: received) != String(dumping: expected) {
+                return handleChildless(expected, expectedMirror, received, receivedMirror, level)
+            }
+            return []
+        }
+
+        let hasDiffNumOfChildren = expectedMirror.children.count != receivedMirror.children.count
+        switch (expectedMirror.displayStyle, receivedMirror.displayStyle) {
+        case (.collection?, .collection?) where hasDiffNumOfChildren,
+             (.dictionary?, .dictionary?) where hasDiffNumOfChildren,
+             (.set?, .set?) where hasDiffNumOfChildren,
+             (.enum?, .enum?) where hasDiffNumOfChildren:
+            return [generateDifferentCountBlock(expected, expectedMirror, received, receivedMirror, level)]
+        case (.dictionary?, .dictionary?):
+            if let expectedDict = expected as? Dictionary<AnyHashable, Any>,
+                let receivedDict = received as? Dictionary<AnyHashable, Any> {
+                var resultLines: [Line] = []
+                expectedDict.keys.forEach { key in
+                    let results = diffLines(expectedDict[key], receivedDict[key], level: level + 1)
+                    if !results.isEmpty {
+                        resultLines.append(Line(contents: "Key \(key.description):", indentationLevel: level, canBeOrdered: true, children: results))
+                    }
+                }
+                return resultLines
+            }
+        case (.set?, .set?):
+            if let expectedSet = expected as? Set<AnyHashable>,
+                let receivedSet = received as? Set<AnyHashable> {
+                return expectedSet.subtracting(receivedSet)
+                    .map { unique in
+                        Line(contents: "Missing: \(unique.description)", indentationLevel: level, canBeOrdered: true)
+                    }
+            }
+        // Handles different enum cases that have children to prevent printing entire object
+        case (.enum?, .enum?) where expectedMirror.children.first?.label != receivedMirror.children.first?.label:
+            let expectedPrintable = enumLabelFromFirstChild(expectedMirror) ?? "UNKNOWN"
+            let receivedPrintable = enumLabelFromFirstChild(receivedMirror) ?? "UNKNOWN"
+            return generateExpectedReceiveLines(expectedPrintable, receivedPrintable, level)
+        default:
+            break
+        }
+
+        var resultLines = [Line]()
+        let zipped = zip(expectedMirror.children, receivedMirror.children)
+        zipped.enumerated().forEach { (index, zippedValues) in
+            let lhs = zippedValues.0
+            let rhs = zippedValues.1
+            let leftDump = String(dumping: lhs.value)
+            if leftDump != String(dumping: rhs.value) {
+                // Remove embedding of `some` for optional types, as it offers no value
+                guard expectedMirror.displayStyle != .optional else {
+                    let results = diffLines(lhs.value, rhs.value, level: level)
+                    resultLines.append(contentsOf: results)
+                    return
+                }
+                if Mirror(reflecting: lhs.value).displayStyle != nil {
+                    let results = diffLines(lhs.value, rhs.value, level: level + 1)
+                    if !results.isEmpty {
+                        let line = Line(contents: "\(expectedMirror.displayStyleDescriptor(index: index))\(lhs.label ?? ""):",
+                            indentationLevel: level,
+                            canBeOrdered: true,
+                            children: results
+                        )
+                        resultLines.append(line)
+                    }
+                } else {
+                    let childName = "\(expectedMirror.displayStyleDescriptor(index: index))\(lhs.label ?? ""):"
+                    let children = generateExpectedReceiveLines(
+                        String(describing: lhs.value),
+                        String(describing: rhs.value),
+                        level + 1
+                    )
+                    resultLines.append(Line(contents: childName, indentationLevel: level, canBeOrdered: true, children: children))
+                }
+            }
+        }
+        return resultLines
+    }
+
+
+    fileprivate func handleChildless<T>(
+        _ expected: T,
+        _ expectedMirror: Mirror,
+        _ received: T,
+        _ receivedMirror: Mirror,
+        _ indentationLevel: Int
+    ) -> [Line] {
+        // Empty collections are "childless", so we may need to generate a different count block instead of treating as a
+        // childless enum.
+        guard !expectedMirror.canBeEmpty else {
+            return [generateDifferentCountBlock(expected, expectedMirror, received, receivedMirror, indentationLevel)]
+        }
+
+        let receivedPrintable: String
+        let expectedPrintable: String
+        // Received mirror has a different number of arguments to expected
+        if receivedMirror.children.count == 0, expectedMirror.children.count != 0 {
+            // Print whole description of received, as it's only a label if childless
+            receivedPrintable = String(dumping: received)
+            // Get the label from the expected, to prevent printing long list of arguments
+            expectedPrintable = enumLabelFromFirstChild(expectedMirror) ?? String(describing: expected)
+        } else if expectedMirror.children.count == 0, receivedMirror.children.count != 0 {
+            receivedPrintable = enumLabelFromFirstChild(receivedMirror) ?? String(describing: received)
+            expectedPrintable = String(dumping: expected)
+        } else {
+            receivedPrintable = String(describing: received)
+            expectedPrintable = String(describing: expected)
+        }
+        return generateExpectedReceiveLines(expectedPrintable, receivedPrintable, indentationLevel)
+    }
+
+    private func generateDifferentCountBlock<T>(
+        _ expected: T,
+        _ expectedMirror: Mirror,
+        _ received: T,
+        _ receivedMirror: Mirror,
+        _ indentationLevel: Int
+    ) -> Line {
+        var expectedPrintable = "(\(expectedMirror.children.count))"
+        var receivedPrintable = "(\(receivedMirror.children.count))"
+        if !skipPrintingOnDiffCount {
+            expectedPrintable.append(" \(expected)")
+            receivedPrintable.append(" \(received)")
+        }
+        return Line(
+            contents: "Different count:",
+            indentationLevel: indentationLevel,
+            canBeOrdered: false,
+            children: generateExpectedReceiveLines(expectedPrintable, receivedPrintable, indentationLevel + 1)
+        )
+    }
+
+    private func generateExpectedReceiveLines(
+        _ expected: String,
+        _ received: String,
+        _ indentationLevel: Int
+    ) -> [Line] {
+        return [
+            Line(contents: "Expected: \(expected)", indentationLevel: indentationLevel, canBeOrdered: false),
+            Line(contents: "Actual\t: \(received)", indentationLevel: indentationLevel, canBeOrdered: false)
+        ]
+    }
+
+    private func buildLineContents(lines: [Line]) -> [String] {
+        let linesContents = lines.map { line in line.generateContents(indentationType: indentationType) }
+        // In the case of this being a top level failure (e.g. both mirrors have no children, like comparing two
+        // primitives `diff(2,3)`, we only want to produce one failure to have proper spacing.
+        let isOnlyTopLevelFailure = lines.map { $0.hasChildren }.filter { $0 }.isEmpty
+        if isOnlyTopLevelFailure {
+            return [linesContents.joined()]
+        } else {
+            return linesContents
+        }
+    }
+}
+
+public enum Difference {
+    /// Styling of the diff indentation.
+    /// `pipe` example:
+    ///     address:
+    ///     |    street:
+    ///     |    |    Received: 2nd Street
+    ///     |    |    Expected: Times Square
+    ///     |    counter:
+    ///     |    |    counter:
+    ///     |    |    |    Received: 1
+    ///     |    |    |    Expected: 2
+    /// `tab` example:
+    ///     address:
+    ///         street:
+    ///             Received: 2nd Street
+    ///             Expected: Times Square
+    ///         counter:
+    ///             counter:
+    ///                 Received: 1
+    ///                 Expected: 2
+    public enum IndentationType: String, CaseIterable {
+        case pipe = "|\t"
+        case tab = "\t"
+    }
+}
+
+private struct Line {
+    let contents: String
+    let indentationLevel: Int
+    let children: [Line]
+    let canBeOrdered: Bool
+
+    var hasChildren: Bool { !children.isEmpty }
+
+    init(
+        contents: String,
+        indentationLevel: Int,
+        canBeOrdered: Bool,
+        children: [Line] = []
+    ) {
+        self.contents = contents
+        self.indentationLevel = indentationLevel
+        self.children = children
+        self.canBeOrdered = canBeOrdered
+    }
+
+    func generateContents(indentationType: IndentationType) -> String {
+        let indentationString = indentation(level: indentationLevel, indentationType: indentationType)
+        let childrenContents = children
+            .sorted { lhs, rhs in
+                guard lhs.canBeOrdered && rhs.canBeOrdered else { return false }
+                return lhs.contents < rhs.contents
+            }
+            .map { $0.generateContents(indentationType: indentationType)}
+            .joined()
+        return "\(indentationString)\(contents)\n" + childrenContents
+    }
+
+    private func indentation(level: Int, indentationType: IndentationType) -> String {
+        (0..<level).reduce("") { acc, _ in acc + "\(indentationType.rawValue)" }
+    }
+}
+
+fileprivate extension String {
+    init<T>(dumping object: T) {
+        self.init()
+        dump(object, to: &self)
+        self = withoutDumpArtifacts
+    }
+
+    // Removes the artifacts of using dumping initialiser to improve readability
+    private var withoutDumpArtifacts: String {
+        self.replacingOccurrences(of: "- ", with: "")
+            .replacingOccurrences(of: "\n", with: "")
+    }
+}
+
+// In the case of an enum with an argument being compared to a different enum case,
+// pull the case name from the mirror
+private func enumLabelFromFirstChild(_ mirror: Mirror) -> String? {
+    switch mirror.displayStyle {
+    case .enum: return mirror.children.first?.label
+    default: return nil
+    }
+}
+
+fileprivate extension Mirror {
+    func displayStyleDescriptor(index: Int) -> String {
+        switch self.displayStyle {
+        case .enum: return "Enum "
+        case .collection: return "Collection[\(index)]"
+        default: return ""
+        }
+    }
+
+    // Used to show "different count" message if mirror has no children,
+    // as some displayStyles can have 0 children.
+    var canBeEmpty: Bool {
+        switch self.displayStyle {
+        case .collection,
+             .dictionary,
+             .set:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+/// Builds list of differences between 2 objects
+///
+/// - Parameters:
+///   - expected: Expected value
+///   - received: Received value
+///   - indentationType: Style of indentation to use
+///   - skipPrintingOnDiffCount: Skips the printing of the object when a collection has a different count
+///
+/// - Returns: List of differences
+public func diff<T>(
+    _ expected: T,
+    _ received: T,
+    indentationType: Difference.IndentationType = .pipe,
+    skipPrintingOnDiffCount: Bool = false
+) -> [String] {
+    Differ(indentationType: indentationType, skipPrintingOnDiffCount: skipPrintingOnDiffCount)
+        .diff(expected, received)
+}
+
+/// Prints list of differences between 2 objects
+///
+/// - Parameters:
+///   - expected: Expected value
+///   - received: Received value
+///   - indentationType: Style of indentation to use
+///   - skipPrintingOnDiffCount: Skips the printing of the object when a collection has a different count
+public func dumpDiff<T: Equatable>(
+    _ expected: T,
+    _ received: T,
+    indentationType: Difference.IndentationType = .pipe,
+    skipPrintingOnDiffCount: Bool = false
+) {
+    // skip equal
+    guard expected != received else {
+        return
+    }
+
+    diff(
+        expected,
+        received,
+        indentationType: indentationType,
+        skipPrintingOnDiffCount: skipPrintingOnDiffCount
+    ).forEach { print($0) }
+}
+
+
+/// Prints list of differences between 2 objects
+///
+/// - Parameters:
+///   - expected: Expected value
+///   - received: Received value
+///   - indentationType: Style of indentation to use
+///   - skipPrintingOnDiffCount: Skips the printing of the object when a collection has a different count
+public func dumpDiff<T>(
+    _ expected: T,
+    _ received: T,
+    indentationType: Difference.IndentationType = .pipe,
+    skipPrintingOnDiffCount: Bool = false
+) {
+    diff(
+        expected,
+        received,
+        indentationType: indentationType,
+        skipPrintingOnDiffCount: skipPrintingOnDiffCount
+    ).forEach { print($0) }
+}

--- a/Sources/Nimble/Utils/Difference.swift
+++ b/Sources/Nimble/Utils/Difference.swift
@@ -49,21 +49,43 @@ private struct Differ {
             if let expectedDict = expected as? Dictionary<AnyHashable, Any>,
                 let receivedDict = received as? Dictionary<AnyHashable, Any> {
                 var resultLines: [Line] = []
-                expectedDict.keys.forEach { key in
+                let missingKeys = Set(expectedDict.keys).subtracting(receivedDict.keys)
+                let extraKeys = Set(receivedDict.keys).subtracting(expectedDict.keys)
+                let commonKeys = Set(receivedDict.keys).intersection(expectedDict.keys)
+                commonKeys.forEach { key in
                     let results = diffLines(expectedDict[key], receivedDict[key], level: level + 1)
                     if !results.isEmpty {
                         resultLines.append(Line(contents: "Key \(key.description):", indentationLevel: level, canBeOrdered: true, children: results))
                     }
+                }
+                if (!missingKeys.isEmpty) {
+                    var missingKeyValuePairs: [Line] = []
+                    missingKeys.forEach { key in
+                        missingKeyValuePairs.append(Line(contents: "\(key.description): \(String(describing: expectedDict[key]))", indentationLevel: level + 1, canBeOrdered: true))
+                    }
+                    resultLines.append(Line(contents: "Missing key: value pairs;", indentationLevel: level, canBeOrdered: false, children: missingKeyValuePairs))
+                }
+                if (!extraKeys.isEmpty) {
+                    var extraKeyValuePairs: [Line] = []
+                    extraKeys.forEach { key in
+                        extraKeyValuePairs.append(Line(contents: "\(key.description): \(String(describing: receivedDict[key]))", indentationLevel: level + 1, canBeOrdered: true))
+                    }
+                    resultLines.append(Line(contents: "Extra key: value pairs;", indentationLevel: level, canBeOrdered: false, children: extraKeyValuePairs))
                 }
                 return resultLines
             }
         case (.set?, .set?):
             if let expectedSet = expected as? Set<AnyHashable>,
                 let receivedSet = received as? Set<AnyHashable> {
-                return expectedSet.subtracting(receivedSet)
+                let missing = expectedSet.subtracting(receivedSet)
                     .map { unique in
                         Line(contents: "Missing: \(unique.description)", indentationLevel: level, canBeOrdered: true)
                     }
+                let extras = receivedSet.subtracting(expectedSet)
+                    .map { unique in
+                        Line(contents: "Extra: \(unique.description)", indentationLevel: level, canBeOrdered: true)
+                    }
+                return missing + extras
             }
         // Handles different enum cases that have children to prevent printing entire object
         case (.enum?, .enum?) where expectedMirror.children.first?.label != receivedMirror.children.first?.label:

--- a/Tests/NimbleTests/DifferenceTests.swift
+++ b/Tests/NimbleTests/DifferenceTests.swift
@@ -1,0 +1,283 @@
+//
+//  DifferenceTests.swift
+//  Difference
+//
+//  Created by Krzysztof Zablocki on 18.10.2017
+//  Copyright © 2017 Krzysztof Zablocki. All rights reserved.
+//
+
+import Nimble
+import Foundation
+import XCTest
+
+typealias IndentationType = Difference.IndentationType
+
+fileprivate struct Person: Equatable {
+    let name: String
+    let age: Int
+    let address: Address
+    let pet: Pet?
+    let petAges: [String: Int]?
+    let favoriteFoods: Set<String>?
+
+    init(
+        name: String = "Krzysztof",
+        age: Int = 29,
+        address: Address = .init(),
+        pet: Pet? = .init(),
+        petAges: [String: Int]? = nil,
+        favoriteFoods: Set<String>? = nil
+    ) {
+        self.name = name
+        self.age = age
+        self.address = address
+        self.pet = pet
+        self.petAges = petAges
+        self.favoriteFoods = favoriteFoods
+    }
+
+    struct Address: Equatable {
+        let street: String
+        let postCode: String
+        let counter: ComplexCounter
+
+        init(
+            street: String = "Times Square",
+            postCode: String = "00-1000",
+            counter: ComplexCounter = .init()
+        ) {
+            self.street = street
+            self.postCode = postCode
+            self.counter = counter
+        }
+
+        struct ComplexCounter: Equatable {
+            let counter: Int
+
+            init(counter: Int = 2) {
+                self.counter = counter
+            }
+        }
+    }
+
+    struct Pet: Equatable {
+        let name: String
+
+        init(name: String = "Fluffy") {
+            self.name = name
+        }
+    }
+}
+
+private enum State {
+    case loaded([Int], String)
+    case anotherLoaded([Int], String)
+    case loadedWithDiffArguments(Int)
+    case loadedWithNoArguments
+}
+
+extension String {
+    func adjustingFor(indentationType: IndentationType) -> String {
+        switch indentationType {
+        case .pipe:
+            return self
+        case .tab:
+            return self.replacingOccurrences(of: "|", with: "")
+        }
+    }
+}
+
+class DifferenceTests: XCTestCase {
+
+    private func runTest<T>(
+        expected: T,
+        received: T,
+        expectedResults: [String],
+        skipPrintingOnDiffCount: Bool = false
+    ) {
+        IndentationType.allCases.forEach { indentationType in
+            let results = diff(expected, received, indentationType: indentationType, skipPrintingOnDiffCount: skipPrintingOnDiffCount)
+            let preppedExpected = expectedResults.map { $0.adjustingFor(indentationType: indentationType) }
+            XCTAssertEqual(results.count, expectedResults.count)
+            XCTAssertEqual(results, preppedExpected)
+        }
+    }
+
+    func testCanFindRootPrimitiveDifference() {
+        runTest(
+            expected: 2,
+            received: 3,
+            expectedResults: ["Received: 3\nExpected: 2\n"]
+        )
+    }
+
+    fileprivate let truth = Person()
+
+    func testCanFindPrimitiveDifference() {
+        runTest(
+            expected: truth,
+            received: Person(age: 30),
+            expectedResults: ["age:\n|\tReceived: 30\n|\tExpected: 29\n"]
+        )
+    }
+
+    func testCanFindMultipleDifference() {
+        runTest(
+            expected: truth,
+            received: Person(name: "Adam", age: 30),
+            expectedResults: [
+                "name:\n|\tReceived: Adam\n|\tExpected: Krzysztof\n",
+                "age:\n|\tReceived: 30\n|\tExpected: 29\n"
+            ]
+        )
+    }
+
+    func testCanFindComplexDifference() {
+        runTest(
+            expected: truth,
+            received: Person(address: Person.Address(street: "2nd Street", counter: .init(counter: 1))),
+            expectedResults: ["address:\n|\tcounter:\n|\t|\tcounter:\n|\t|\t|\tReceived: 1\n|\t|\t|\tExpected: 2\n|\tstreet:\n|\t|\tReceived: 2nd Street\n|\t|\tExpected: Times Square\n"]
+        )
+    }
+
+    func testCanGiveDescriptionForOptionalOnLeftSide() {
+        let results = diff(Person(pet: nil), Person())
+        XCTAssertEqual(results.count, 1)
+    }
+
+    func testCanGiveDescriptionForOptionalOnRightSide() {
+        let results = diff(Person(), Person(pet: nil))
+        XCTAssertEqual(results.count, 1)
+    }
+
+    // MARK: Collections
+
+    func test_canFindCollectionCountDifference() {
+        runTest(
+            expected: [1],
+            received: [1, 3],
+            expectedResults: ["Different count:\n|\tReceived: (2) [1, 3]\n|\tExpected: (1) [1]\n"]
+        )
+    }
+
+    func test_canFindCollectionCountDifference_complex() {
+        runTest(
+            expected: State.loaded([1, 2], "truthString"),
+            received: State.loaded([], "stubString"),
+            expectedResults: ["Enum loaded:\n|\t.0:\n|\t|\tDifferent count:\n|\t|\t|\tReceived: (0) []\n|\t|\t|\tExpected: (2) [1, 2]\n|\t.1:\n|\t|\tReceived: stubString\n|\t|\tExpected: truthString\n"]
+        )
+    }
+
+    func test_collectionCountDifference_withoutPrintingObject() {
+        dumpDiff([1], [1, 3], indentationType: .pipe, skipPrintingOnDiffCount: true)
+        runTest(
+            expected: [1],
+            received: [1, 3],
+            expectedResults: ["Different count:\n|\tReceived: (2)\n|\tExpected: (1)\n"],
+            skipPrintingOnDiffCount: true
+        )
+    }
+
+    func test_labelsArrayElementsInDiff() {
+        runTest(
+            expected: [Person(), Person(name: "John")],
+            received: [Person(name: "John"), Person()],
+            expectedResults: [
+                "Collection[0]:\n|\tname:\n|\t|\tReceived: John\n|\t|\tExpected: Krzysztof\n",
+                "Collection[1]:\n|\tname:\n|\t|\tReceived: Krzysztof\n|\t|\tExpected: John\n"
+            ]
+        )
+    }
+
+    // MARK: Enums
+
+    func test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical() {
+        runTest(
+            expected: State.loaded([0], "CommonString"),
+            received: State.anotherLoaded([0], "CommonString"),
+            expectedResults: ["Received: anotherLoaded\nExpected: loaded\n"]
+        )
+    }
+
+    func test_canFindEnumCaseDifferenceWhenLessArguments() {
+        runTest(
+            expected: State.loaded([0], "CommonString"),
+            received: State.loadedWithDiffArguments(1),
+            expectedResults: ["Received: loadedWithDiffArguments\nExpected: loaded\n"]
+        )
+    }
+
+    // MARK: Dictionaries
+
+    func test_canFindDictionaryCountDifference() {
+        runTest(
+            expected: Person(petAges: ["Henny": 4]),
+            received: Person(petAges: [:]),
+            expectedResults: ["petAges:\n|\tDifferent count:\n|\t|\tReceived: (0) [:]\n|\t|\tExpected: (1) [\"Henny\": 4]\n"]
+        )
+    }
+
+    func test_canFindOptionalDifferenceBetweenSomeAndNone() {
+        runTest(
+            expected: Person(petAges: ["Henny": 4]),
+            received: Person(petAges: nil),
+            expectedResults: ["petAges:\n|\tReceived: nil\n|\tExpected: Optional([\"Henny\": 4])\n"]
+        )
+    }
+
+    func test_canFindDictionaryDifference() {
+        runTest(
+            expected: Person(petAges: ["Henny": 4, "Jethro": 6]),
+            received: Person(petAges: ["Henny": 1, "Jethro": 2]),
+            expectedResults: ["petAges:\n|\tKey Henny:\n|\t|\tReceived: 1\n|\t|\tExpected: 4\n|\tKey Jethro:\n|\t|\tReceived: 2\n|\t|\tExpected: 6\n"]
+        )
+    }
+
+    // MARK: Sets
+
+    func test_canFindSetCountDifference() {
+        runTest(
+            expected: Person(favoriteFoods: []),
+            received: Person(favoriteFoods: ["Oysters"]),
+            expectedResults: ["favoriteFoods:\n|\tDifferent count:\n|\t|\tReceived: (1) [\"Oysters\"]\n|\t|\tExpected: (0) []\n"]
+        )
+    }
+
+    func test_canFindOptionalSetDifferenceBetweenSomeAndNone() {
+        runTest(
+            expected: Person(favoriteFoods: ["Oysters"]),
+            received: Person(favoriteFoods: nil),
+            expectedResults: ["favoriteFoods:\n|\tReceived: nil\n|\tExpected: Optional(Set([\"Oysters\"]))\n"]
+        )
+    }
+
+    func test_canFindSetDifference() {
+        runTest(
+            expected: Person(favoriteFoods: ["Sushi", "Pizza"]),
+            received: Person(favoriteFoods: ["Oysters", "Crab"]),
+            expectedResults: ["favoriteFoods:\n|\tMissing: Pizza\n|\tMissing: Sushi\n"]
+        )
+    }
+}
+
+extension DifferenceTests {
+    static var allTests = [
+        ("testCanFindRootPrimitiveDifference", testCanFindRootPrimitiveDifference),
+        ("testCanFindPrimitiveDifference", testCanFindPrimitiveDifference),
+        ("testCanFindMultipleDifference", testCanFindMultipleDifference),
+        ("testCanFindComplexDifference", testCanFindComplexDifference),
+        ("testCanGiveDescriptionForOptionalOnLeftSide", testCanGiveDescriptionForOptionalOnLeftSide),
+        ("testCanGiveDescriptionForOptionalOnRightSide", testCanGiveDescriptionForOptionalOnRightSide),
+        ("test_canFindCollectionCountDifference", test_canFindCollectionCountDifference),
+        ("test_canFindCollectionCountDifference_complex", test_canFindCollectionCountDifference_complex),
+        ("test_labelsArrayElementsInDiff", test_labelsArrayElementsInDiff),
+        ("test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical", test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical),
+        ("test_canFindEnumCaseDifferenceWhenLessArguments", test_canFindEnumCaseDifferenceWhenLessArguments),
+        ("test_canFindDictionaryCountDifference", test_canFindDictionaryCountDifference),
+        ("test_canFindOptionalDifferenceBetweenSomeAndNone", test_canFindOptionalDifferenceBetweenSomeAndNone),
+        ("test_canFindDictionaryDifference", test_canFindDictionaryDifference),
+        ("test_canFindSetCountDifference", test_canFindSetCountDifference),
+        ("test_canFindOptionalSetDifferenceBetweenSomeAndNone", test_canFindOptionalSetDifferenceBetweenSomeAndNone),
+        ("test_canFindSetDifference", test_canFindSetDifference)
+    ]
+}

--- a/Tests/NimbleTests/DifferenceTests.swift
+++ b/Tests/NimbleTests/DifferenceTests.swift
@@ -83,6 +83,8 @@ extension String {
             return self
         case .tab:
             return self.replacingOccurrences(of: "|", with: "")
+        @unknown default:
+            fatalError("unknown indentation type \(indentationType)")
         }
     }
 }
@@ -107,7 +109,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: 2,
             received: 3,
-            expectedResults: ["Received: 3\nExpected: 2\n"]
+            expectedResults: ["Expected: 2\nActual\t: 3\n"]
         )
     }
 
@@ -117,7 +119,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: truth,
             received: Person(age: 30),
-            expectedResults: ["age:\n|\tReceived: 30\n|\tExpected: 29\n"]
+            expectedResults: ["age:\n|\tExpected: 29\n|\tActual\t: 30\n"]
         )
     }
 
@@ -126,8 +128,8 @@ class DifferenceTests: XCTestCase {
             expected: truth,
             received: Person(name: "Adam", age: 30),
             expectedResults: [
-                "name:\n|\tReceived: Adam\n|\tExpected: Krzysztof\n",
-                "age:\n|\tReceived: 30\n|\tExpected: 29\n"
+                "name:\n|\tExpected: Krzysztof\n|\tActual\t: Adam\n",
+                "age:\n|\tExpected: 29\n|\tActual\t: 30\n"
             ]
         )
     }
@@ -136,7 +138,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: truth,
             received: Person(address: Person.Address(street: "2nd Street", counter: .init(counter: 1))),
-            expectedResults: ["address:\n|\tcounter:\n|\t|\tcounter:\n|\t|\t|\tReceived: 1\n|\t|\t|\tExpected: 2\n|\tstreet:\n|\t|\tReceived: 2nd Street\n|\t|\tExpected: Times Square\n"]
+            expectedResults: ["address:\n|\tcounter:\n|\t|\tcounter:\n|\t|\t|\tExpected: 2\n|\t|\t|\tActual\t: 1\n|\tstreet:\n|\t|\tExpected: Times Square\n|\t|\tActual\t: 2nd Street\n"]
         )
     }
 
@@ -156,7 +158,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: [1],
             received: [1, 3],
-            expectedResults: ["Different count:\n|\tReceived: (2) [1, 3]\n|\tExpected: (1) [1]\n"]
+            expectedResults: ["Different count:\n|\tExpected: (1) [1]\n|\tActual\t: (2) [1, 3]\n"]
         )
     }
 
@@ -164,7 +166,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: State.loaded([1, 2], "truthString"),
             received: State.loaded([], "stubString"),
-            expectedResults: ["Enum loaded:\n|\t.0:\n|\t|\tDifferent count:\n|\t|\t|\tReceived: (0) []\n|\t|\t|\tExpected: (2) [1, 2]\n|\t.1:\n|\t|\tReceived: stubString\n|\t|\tExpected: truthString\n"]
+            expectedResults: ["Enum loaded:\n|\t.0:\n|\t|\tDifferent count:\n|\t|\t|\tExpected: (2) [1, 2]\n|\t|\t|\tActual\t: (0) []\n|\t.1:\n|\t|\tExpected: truthString\n|\t|\tActual\t: stubString\n"]
         )
     }
 
@@ -173,7 +175,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: [1],
             received: [1, 3],
-            expectedResults: ["Different count:\n|\tReceived: (2)\n|\tExpected: (1)\n"],
+            expectedResults: ["Different count:\n|\tExpected: (1)\n|\tActual\t: (2)\n"],
             skipPrintingOnDiffCount: true
         )
     }
@@ -183,8 +185,8 @@ class DifferenceTests: XCTestCase {
             expected: [Person(), Person(name: "John")],
             received: [Person(name: "John"), Person()],
             expectedResults: [
-                "Collection[0]:\n|\tname:\n|\t|\tReceived: John\n|\t|\tExpected: Krzysztof\n",
-                "Collection[1]:\n|\tname:\n|\t|\tReceived: Krzysztof\n|\t|\tExpected: John\n"
+                "Collection[0]:\n|\tname:\n|\t|\tExpected: Krzysztof\n|\t|\tActual\t: John\n",
+                "Collection[1]:\n|\tname:\n|\t|\tExpected: John\n|\t|\tActual\t: Krzysztof\n"
             ]
         )
     }
@@ -195,7 +197,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: State.loaded([0], "CommonString"),
             received: State.anotherLoaded([0], "CommonString"),
-            expectedResults: ["Received: anotherLoaded\nExpected: loaded\n"]
+            expectedResults: ["Expected: loaded\nActual\t: anotherLoaded\n"]
         )
     }
 
@@ -203,7 +205,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: State.loaded([0], "CommonString"),
             received: State.loadedWithDiffArguments(1),
-            expectedResults: ["Received: loadedWithDiffArguments\nExpected: loaded\n"]
+            expectedResults: ["Expected: loaded\nActual\t: loadedWithDiffArguments\n"]
         )
     }
 
@@ -213,7 +215,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: Person(petAges: ["Henny": 4]),
             received: Person(petAges: [:]),
-            expectedResults: ["petAges:\n|\tDifferent count:\n|\t|\tReceived: (0) [:]\n|\t|\tExpected: (1) [\"Henny\": 4]\n"]
+            expectedResults: ["petAges:\n|\tDifferent count:\n|\t|\tExpected: (1) [\"Henny\": 4]\n|\t|\tActual\t: (0) [:]\n"]
         )
     }
 
@@ -221,7 +223,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: Person(petAges: ["Henny": 4]),
             received: Person(petAges: nil),
-            expectedResults: ["petAges:\n|\tReceived: nil\n|\tExpected: Optional([\"Henny\": 4])\n"]
+            expectedResults: ["petAges:\n|\tExpected: Optional([\"Henny\": 4])\n|\tActual\t: nil\n"]
         )
     }
 
@@ -229,7 +231,15 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: Person(petAges: ["Henny": 4, "Jethro": 6]),
             received: Person(petAges: ["Henny": 1, "Jethro": 2]),
-            expectedResults: ["petAges:\n|\tKey Henny:\n|\t|\tReceived: 1\n|\t|\tExpected: 4\n|\tKey Jethro:\n|\t|\tReceived: 2\n|\t|\tExpected: 6\n"]
+            expectedResults: ["petAges:\n|\tKey Henny:\n|\t|\tExpected: 4\n|\t|\tActual\t: 1\n|\tKey Jethro:\n|\t|\tExpected: 6\n|\t|\tActual\t: 2\n"]
+        )
+    }
+
+    func test_canFindDictionaryKeyDifference() {
+        runTest(
+            expected: Person(petAges: ["Haddie": 4, "Jethro": 6]),
+            received: Person(petAges: ["Henny": 1, "Jethro": 2]),
+            expectedResults: ["petAges:\n|\tKey Jethro:\n|\t|\tExpected: 6\n|\t|\tActual\t: 2\n|\tMissing key: value pairs;\n|\t|\tHaddie: Optional(4)\n|\tExtra key: value pairs;\n|\t|\tHenny: Optional(1)\n"]
         )
     }
 
@@ -239,7 +249,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: Person(favoriteFoods: []),
             received: Person(favoriteFoods: ["Oysters"]),
-            expectedResults: ["favoriteFoods:\n|\tDifferent count:\n|\t|\tReceived: (1) [\"Oysters\"]\n|\t|\tExpected: (0) []\n"]
+            expectedResults: ["favoriteFoods:\n|\tDifferent count:\n|\t|\tExpected: (0) []\n|\t|\tActual\t: (1) [\"Oysters\"]\n"]
         )
     }
 
@@ -247,7 +257,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: Person(favoriteFoods: ["Oysters"]),
             received: Person(favoriteFoods: nil),
-            expectedResults: ["favoriteFoods:\n|\tReceived: nil\n|\tExpected: Optional(Set([\"Oysters\"]))\n"]
+            expectedResults: ["favoriteFoods:\n|\tExpected: Optional(Set([\"Oysters\"]))\n|\tActual\t: nil\n"]
         )
     }
 
@@ -255,7 +265,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: Person(favoriteFoods: ["Sushi", "Pizza"]),
             received: Person(favoriteFoods: ["Oysters", "Crab"]),
-            expectedResults: ["favoriteFoods:\n|\tMissing: Pizza\n|\tMissing: Sushi\n"]
+            expectedResults: ["favoriteFoods:\n|\tExtra: Crab\n|\tExtra: Oysters\n|\tMissing: Pizza\n|\tMissing: Sushi\n"]
         )
     }
 }
@@ -276,6 +286,7 @@ extension DifferenceTests {
         ("test_canFindDictionaryCountDifference", test_canFindDictionaryCountDifference),
         ("test_canFindOptionalDifferenceBetweenSomeAndNone", test_canFindOptionalDifferenceBetweenSomeAndNone),
         ("test_canFindDictionaryDifference", test_canFindDictionaryDifference),
+        ("test_canFindDictionaryKeyDifference", test_canFindDictionaryKeyDifference),
         ("test_canFindSetCountDifference", test_canFindSetCountDifference),
         ("test_canFindOptionalSetDifferenceBetweenSomeAndNone", test_canFindOptionalSetDifferenceBetweenSomeAndNone),
         ("test_canFindSetDifference", test_canFindSetDifference)


### PR DESCRIPTION
From Xcode 12.5 beta release notes:
```
XCTest’s legacy Swift overlay library (libswiftXCTest.dylib) has been removed.
Don’t use this library; instead use its replacement, libXCTestSwiftSupport.dylib.
```

If the link is just removed, Xcode automatically adds the new overlay library.
Verified by building using `xcodebuild build-for-testing` and verifying that the
library exist in the resulting test bundle. Previous version also work with this
change.