### PR TITLE
Nimble: bump LastUpgradeCheck to eliminate Xcode proj warnings.

### DIFF
--- a/Nimble.xcodeproj/project.pbxproj
+++ b/Nimble.xcodeproj/project.pbxproj
@@ -1230,7 +1230,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1250;
+				LastUpgradeCheck = 1500;
 				ORGANIZATIONNAME = "Jeff Hui";
 				TargetAttributes = {
 					1F1A74281940169200FFFC47 = {

--- a/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-iOS.xcscheme
+++ b/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1500"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-macOS.xcscheme
+++ b/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1500"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-tvOS.xcscheme
+++ b/Nimble.xcodeproj/xcshareddata/xcschemes/Nimble-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Motivation is explained in commit's message.

@barakwei pls note that this PR targets the `lightricks-9.2.1+arm64-throw-support` branch (that seems to be the branch that we're using in foundations).