### PR TITLE
BeLogical: fix retroactive conformance errors.

### DIFF
--- a/Sources/Nimble/Matchers/BeLogical.swift
+++ b/Sources/Nimble/Matchers/BeLogical.swift
@@ -1,42 +1,42 @@
 import Foundation
 
-extension Int8: ExpressibleByBooleanLiteral {
+extension Int8: Swift.ExpressibleByBooleanLiteral {
     public init(booleanLiteral value: Bool) {
         self = NSNumber(value: value).int8Value
     }
 }
 
-extension UInt8: ExpressibleByBooleanLiteral {
+extension UInt8: Swift.ExpressibleByBooleanLiteral {
     public init(booleanLiteral value: Bool) {
         self = NSNumber(value: value).uint8Value
     }
 }
 
-extension Int16: ExpressibleByBooleanLiteral {
+extension Int16: Swift.ExpressibleByBooleanLiteral {
     public init(booleanLiteral value: Bool) {
         self = NSNumber(value: value).int16Value
     }
 }
 
-extension UInt16: ExpressibleByBooleanLiteral {
+extension UInt16: Swift.ExpressibleByBooleanLiteral {
     public init(booleanLiteral value: Bool) {
         self = NSNumber(value: value).uint16Value
     }
 }
 
-extension Int32: ExpressibleByBooleanLiteral {
+extension Int32: Swift.ExpressibleByBooleanLiteral {
     public init(booleanLiteral value: Bool) {
         self = NSNumber(value: value).int32Value
     }
 }
 
-extension UInt32: ExpressibleByBooleanLiteral {
+extension UInt32: Swift.ExpressibleByBooleanLiteral {
     public init(booleanLiteral value: Bool) {
         self = NSNumber(value: value).uint32Value
     }
 }
 
-extension Int64: ExpressibleByBooleanLiteral {
+extension Int64: Swift.ExpressibleByBooleanLiteral {
     public init(booleanLiteral value: Bool) {
         self = NSNumber(value: value).int64Value
     }


### PR DESCRIPTION
Fixes the warning in the new Swift version solved here:
https://github.com/swiftlang/swift/pull/36068

Which is:

Extension declares a conformance of imported type 'X' to imported protocol 'Y'; this will not behave correctly if the owners of 'CoreFoundation' introduce this conformance in the future

without adding the @retroactive, which does not compile in Xcode 15.

This way, extensions that declares a conformance to a type where both are from another module will compile without warning in Xcode 16, as the conformed type is declared to be explicitly from the imported module, which suppresses the warning.